### PR TITLE
Remove read from MSR_IA32_VMX_VMFUNC

### DIFF
--- a/shv.h
+++ b/shv.h
@@ -75,7 +75,7 @@ typedef struct _SHV_VP_DATA
     ULONG VpIndex;
     volatile ULONG VmxEnabled;
     ULONG64 SystemDirectoryTableBase;
-    LARGE_INTEGER MsrData[18];
+    LARGE_INTEGER MsrData[17];
     ULONGLONG VmxOnPhysicalAddress;
     ULONGLONG VmcsPhysicalAddress;
     ULONGLONG MsrBitmapPhysicalAddress;


### PR DESCRIPTION
By adjusting MsrData we can prevent a read from MSR_IA32_VMX_VMFUNC, which wasn't available before Haswell processors and is not referenced in this project anyway.

Fixes #5