### PR TITLE
Update shvos.c

### DIFF
--- a/nt/shvos.c
+++ b/nt/shvos.c
@@ -151,16 +151,16 @@ ShvOsDpcRoutine (
     KeSignalCallDpcDone(SystemArgument1);
 }
 
-VOID
+INT32
 ShvOsPrepareProcessor (
     _In_ PSHV_VP_DATA VpData
     )
 {
     //
-    // Nothing to do on NT
+    // Nothing to do on NT, only return SHV_STATUS_SUCCESS
     //
     UNREFERENCED_PARAMETER(VpData);
-    NOTHING;
+    return SHV_STATUS_SUCCESS;
 }
 
 VOID


### PR DESCRIPTION
In ShvVpInitialize, there is a branch checking for SHV_STATUS_SUCCESS, added in one of the commits supporting UEFI (f5dd1af).
If you want to share code between nt and uefi, the nt version of ShvOsPrepareProcessor should return SHV_STATUS_SUCCESS in default flow :)