### PR TITLE
Fix memory leak in shvvp.c

### DIFF
--- a/shvvp.c
+++ b/shvvp.c
@@ -261,8 +261,10 @@ ShvVpLoadCallback (
     if (status != SHV_STATUS_SUCCESS)
     {
         //
-        // Bail out
+        // Bail out, free the allocated per-processor data
+        // Can't free it in Failure, since need to distinguish between the different flows
         //
+        ShvVpFreeData(vpData, 1);
         goto Failure;
     }
 

--- a/shvvp.c
+++ b/shvvp.c
@@ -224,9 +224,11 @@ ShvVpLoadCallback (
     _In_ PSHV_CALLBACK_CONTEXT Context
     )
 {
-    PSHV_VP_DATA vpData = NULL;
+    PSHV_VP_DATA vpData;
     INT32 status;
 
+    vpData = NULL;
+    
     //
     // Detect if the hardware appears to support VMX root mode to start.
     // No attempts are made to enable this if it is lacking or disabled.

--- a/shvvp.c
+++ b/shvvp.c
@@ -224,7 +224,7 @@ ShvVpLoadCallback (
     _In_ PSHV_CALLBACK_CONTEXT Context
     )
 {
-    PSHV_VP_DATA vpData;
+    PSHV_VP_DATA vpData = NULL;
     INT32 status;
 
     //
@@ -262,9 +262,7 @@ ShvVpLoadCallback (
     {
         //
         // Bail out, free the allocated per-processor data
-        // Can't free it in Failure, since need to distinguish between the different flows
         //
-        ShvVpFreeData(vpData, 1);
         goto Failure;
     }
 
@@ -277,7 +275,6 @@ ShvVpLoadCallback (
         //
         // Free the per-processor data
         //
-        ShvVpFreeData(vpData, 1);
         status = SHV_STATUS_NOT_PRESENT;
         goto Failure;
     }
@@ -292,6 +289,10 @@ Failure:
     //
     // Return failure
     //
+    if (vpData != NULL)
+    {
+        ShvVpFreeData(vpData, 1);
+    }
     Context->FailedCpu = ShvOsGetCurrentProcessorNumber();
     Context->FailureStatus = status;
     return;


### PR DESCRIPTION
Fix memory leak in ShvVpLoadCallback. There is a flow (when ShvVpInitialize is failed) that the per-processor data is not freed before the goto Failure and return. Of-course, we can't free it in the Failure, since we need to distinguish between different flows of failures (fail to allocate, fail to initialize, hypervisor not present) So just keep freeing it anytime we fail for some reason (just as when our hypervisor is not present on line 275).
Thanks :)