### PR TITLE
Remove VM_EXIT_ACK_INTR_ON_EXIT flag and fix BSOD

### DIFF
--- a/nt/shvos.c
+++ b/nt/shvos.c
@@ -418,6 +418,17 @@ DriverEntry (
     //
     // Load the hypervisor
     //
-    return ShvOsErrorToError(ShvLoad());
+    status = ShvOsErrorToError(ShvLoad());
+
+    //
+    // If load of the hypervisor happened to fail, unregister previously registered
+    // power callback, otherwise we would get BSOD on shutdown.
+    //
+    if (!NT_SUCCESS(status))
+    {
+        ExUnregisterCallback(g_PowerCallbackRegistration);
+    }
+
+    return status;
 }
 

--- a/shvvmx.c
+++ b/shvvmx.c
@@ -361,12 +361,10 @@ ShvVmxSetupVmcsForVp (
                                             CPU_BASED_ACTIVATE_SECONDARY_CONTROLS));
 
     //
-    // If any interrupts were pending upon entering the hypervisor, acknowledge
-    // them when we're done. And make sure to enter us in x64 mode at all times
+    // Make sure to enter us in x64 mode at all times.
     //
     __vmx_vmwrite(VM_EXIT_CONTROLS,
                            ShvUtilAdjustMsr(VpData->MsrData[15],
-                                            VM_EXIT_ACK_INTR_ON_EXIT |
                                             VM_EXIT_IA32E_MODE));
 
     //


### PR DESCRIPTION
Hi,
These two separate commits fix two unrelated issues:
- Removal of VM_EXIT_ACK_INTR_ON_EXIT flag, which is not needed, because PIN_BASED_EXT_INTR is not set (as discussed in #31) and its setting may create just confusion for newcomers.
- Fixing BSOD in situation where DriverEntry->ShvLoad fails. Code before patch forgets to unregister PowerCallback (note that DriverUnload is not called when DriverEntry fails), which leaves PowerCallback leaked. When Windows is about to do shutdown or reboot, it tries to call this unregistered callback, but because the driver is already unloaded, it results in critical page-fault and BSOD.

Patches has been tested in VMWare.