### PR TITLE
ShvVmxMtrrAdjustEffectiveMemoryType: Fixed off-by-one edge case in memory type assignment

### DIFF
--- a/shvvmx.c
+++ b/shvvmx.c
@@ -96,7 +96,7 @@ ShvVmxMtrrAdjustEffectiveMemoryType (
             // Check if this large page falls within the boundary. If a single
             // physical page (4KB) touches it, we need to override the entire 2MB.
             //
-            if (((LargePageAddress + _2MB - 1) >= VpData->MtrrData[i].PhysicalAddressMin) &&
+            if (((LargePageAddress + (_2MB - 1)) >= VpData->MtrrData[i].PhysicalAddressMin) &&
                 (LargePageAddress <= VpData->MtrrData[i].PhysicalAddressMax))
             {
                 //

--- a/shvvmx.c
+++ b/shvvmx.c
@@ -96,7 +96,7 @@ ShvVmxMtrrAdjustEffectiveMemoryType (
             // Check if this large page falls within the boundary. If a single
             // physical page (4KB) touches it, we need to override the entire 2MB.
             //
-            if (((LargePageAddress + _2MB) >= VpData->MtrrData[i].PhysicalAddressMin) &&
+            if (((LargePageAddress + _2MB - 1) >= VpData->MtrrData[i].PhysicalAddressMin) &&
                 (LargePageAddress <= VpData->MtrrData[i].PhysicalAddressMax))
             {
                 //


### PR DESCRIPTION
There is a miscalculation in the range of a singular 2MB frame which causes an extraneous frame to be marked as the wrong cache type at the beginning of the range. This is because the code incorrectly checks a range of a given frame to be 0 to 2MB instead of 0 to 2MB-1 inclusive.

Consider the following case:

* An MTRR Variable Range Register marks the following range as UC:
    - Begin=`0xC0000000 `
    - End=`0xFFFFFFFF`
* Frame number 0x5FF is preparing to be marked, which has only addresses that fall outside the range above.
    - `LargePageAddress` = `(0x5FF * 2MB)` = `0xBFE00000`
    - ` LargePageAddress + _2MB ` = `(0x5FF + 1) * 2MB` = `0xC0000000` <-- **Incorrect**
    - `VpData->MtrrData[i].PhysicalAddressMin` = `0xC0000000`
* The range check is made
    - `((LargePageAddress + _2MB) >= VpData->MtrrData[i].PhysicalAddressMin)`
    - `LargePageAddress + _2MB >= 0xC0000000` evaluates to `TRUE` (**Incorrect**)

The fix is simple, just only check the range of 0 to 2MB-1 for every frame.