### PR TITLE
Clear the AC flag before capturing it

### DIFF
--- a/shvvp.c
+++ b/shvvp.c
@@ -132,6 +132,13 @@ ShvVpInitialize (
     ShvCaptureSpecialRegisters(&Data->SpecialRegisters);
 
     //
+    // Make sure the AC flags in the EFLAGS is cleared before capturing the
+    // register. This flag is checked as an indicator of whether the VM is
+    // launched below.
+    //
+    __writeeflags(__readeflags() & ~EFLAGS_ALIGN_CHECK);
+
+    //
     // Then, capture the entire register state. We will need this, as once we
     // launch the VM, it will begin execution at the defined guest instruction
     // pointer, which we set to ShvVpRestoreAfterLaunch, with the registers set


### PR DESCRIPTION
On some systems, the AC flag was already set when it is captured by SimpleVisor. This results in skipping initialization of the hypervisor and `The SHV failed to initialize (0xFFFFFFFD) Failed CPU: 0` error because the subsequent check after capturing believes the hypervisor was already set up.

I found my VM (18362.1.amd64fre.19h1_release.190318-1202) hit this case. 

This change clears the flag prior to capturing and checking the flag, ensuring initialization happens.