### PR TITLE
added 2 things that were breaking the vcxproj when compiling with vs2022

### DIFF
--- a/shv.vcxproj
+++ b/shv.vcxproj
@@ -13,9 +13,16 @@
   <PropertyGroup Label="Globals">
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{4C048BB2-7E8D-43BF-B29D-942461275023}</ProjectGuid>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='UEFI|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='NT|x64'">
+	<TargetVersion>Windows10</TargetVersion>
+    <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
+  </PropertyGroup>
   <Import Project="$(Configuration)\$(Configuration).default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)'=='UEFI'">
@@ -29,13 +36,23 @@
   <PropertyGroup>
     <IncludePath>$(IncludePath);$(VC_IncludePath)</IncludePath>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='NT|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+	<DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="nt\shvos.c" />
     <ClCompile Include="shv.c" />
     <ClCompile Include="shvutil.c" />
     <ClCompile Include="shvvmx.c" />
     <ClCompile Include="shvvmxhv.c" />
     <ClCompile Include="shvvp.c" />
-    <ClCompile Include="$(Configuration)\shvos.c"/>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="shv.h" />
@@ -44,7 +61,11 @@
     <ClInclude Include="vmx.h" />
   </ItemGroup>
   <ItemGroup>
+    <MASM Include="nt\shvosx64.asm" />
     <MASM Include="shvvmxhvx64.asm" />
-    <MASM Include="$(Configuration)\shvosx64.asm"/>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="nt\nt.default.props" />
+    <None Include="nt\nt.props" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When transitioning from an older version of visual studio to vs2022 it is necessary to have <TargetVersion>Windows10</TargetVersion> in the vcxproj, also, due to an update to the microsoft signtool you have to put the digest algorithm in the vcxproj as well.