### PR TITLE
Add UEFI runtime memory support for hypervisor page tables and IDT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "VisualUefi"]
+	path = VisualUefi
+	url = https://github.com/ionescu007/VisualUefi.git

--- a/shv.vcxproj
+++ b/shv.vcxproj
@@ -35,7 +35,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='UEFI|x64'">
     <ClCompile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <OmitFramePointers>false</OmitFramePointers>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
+    <Link>
+      <SubSystem>EFI Runtime</SubSystem>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="shv.c" />
@@ -48,6 +55,7 @@
   <ItemGroup>
     <ClInclude Include="shv.h" />
     <ClInclude Include="ntint.h" />
+    <ClInclude Include="shvdbg.h" />
     <ClInclude Include="shv_x.h" />
     <ClInclude Include="vmx.h" />
   </ItemGroup>

--- a/shv.vcxproj
+++ b/shv.vcxproj
@@ -13,9 +13,12 @@
   <PropertyGroup Label="Globals">
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{4C048BB2-7E8D-43BF-B29D-942461275023}</ProjectGuid>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='UEFI|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(Configuration)\$(Configuration).default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)'=='UEFI'">
@@ -29,13 +32,18 @@
   <PropertyGroup>
     <IncludePath>$(IncludePath);$(VC_IncludePath)</IncludePath>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='UEFI|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="shv.c" />
     <ClCompile Include="shvutil.c" />
     <ClCompile Include="shvvmx.c" />
     <ClCompile Include="shvvmxhv.c" />
     <ClCompile Include="shvvp.c" />
-    <ClCompile Include="$(Configuration)\shvos.c"/>
+    <ClCompile Include="$(Configuration)\shvos.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="shv.h" />
@@ -45,6 +53,6 @@
   </ItemGroup>
   <ItemGroup>
     <MASM Include="shvvmxhvx64.asm" />
-    <MASM Include="$(Configuration)\shvosx64.asm"/>
+    <MASM Include="$(Configuration)\shvosx64.asm" />
   </ItemGroup>
 </Project>

--- a/shv.vcxproj.filters
+++ b/shv.vcxproj.filters
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/shv.vcxproj.filters
+++ b/shv.vcxproj.filters
@@ -13,6 +13,7 @@
     <ClInclude Include="ntint.h" />
     <ClInclude Include="shv_x.h" />
     <ClInclude Include="vmx.h" />
+    <ClInclude Include="shvdbg.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="shvvmxhvx64.asm" />

--- a/shv.vcxproj.filters
+++ b/shv.vcxproj.filters
@@ -1,3 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="shv.c" />
+    <ClCompile Include="shvutil.c" />
+    <ClCompile Include="shvvmx.c" />
+    <ClCompile Include="shvvmxhv.c" />
+    <ClCompile Include="shvvp.c" />
+    <ClCompile Include="$(Configuration)\shvos.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="shv.h" />
+    <ClInclude Include="ntint.h" />
+    <ClInclude Include="shv_x.h" />
+    <ClInclude Include="vmx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <MASM Include="shvvmxhvx64.asm" />
+    <MASM Include="$(Configuration)\shvosx64.asm" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="uefi">
+      <UniqueIdentifier>{b9114a28-d5ed-43b4-b29b-f2e425d309a5}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
 </Project>

--- a/shv.vcxproj.user
+++ b/shv.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/shv_x.h
+++ b/shv_x.h
@@ -81,6 +81,7 @@ typedef struct _SHV_VP_DATA
             UINT64 MsrBitmapPhysicalAddress;
             UINT64 EptPml4PhysicalAddress;
             UINT32 EptControls;
+            UINT64 HostIdtBase;
         };
     };
 

--- a/shvvmx.c
+++ b/shvvmx.c
@@ -468,7 +468,20 @@ ShvVmxSetupVmcsForVp (
     //
     __vmx_vmwrite(GUEST_IDTR_BASE, (uintptr_t)state->Idtr.Base);
     __vmx_vmwrite(GUEST_IDTR_LIMIT, state->Idtr.Limit);
-    __vmx_vmwrite(HOST_IDTR_BASE, (uintptr_t)state->Idtr.Base);
+
+    //
+    // For the host IDT, use a custom persistent IDT if one was built (UEFI
+    // path), since the firmware IDT resides in boot services memory and will
+    // be freed after ExitBootServices. Otherwise use the captured IDT (NT path).
+    //
+    if (VpData->HostIdtBase != 0)
+    {
+        __vmx_vmwrite(HOST_IDTR_BASE, VpData->HostIdtBase);
+    }
+    else
+    {
+        __vmx_vmwrite(HOST_IDTR_BASE, (uintptr_t)state->Idtr.Base);
+    }
 
     //
     // Load CR0

--- a/uefi/shvos.c
+++ b/uefi/shvos.c
@@ -155,6 +155,117 @@ ShvOsUnprepareProcessor (
 }
 
 INT32
+ShvOsBuildHostPageTables (
+    _In_ PSHV_VP_DATA VpData
+    )
+{
+    UINT64 *Pml4, *Pdpt, *Pd;
+    UINT32 i, j;
+
+    //
+    // The UEFI firmware's page tables (CR3) reside in EfiBootServicesData
+    // memory and will be freed after ExitBootServices. The hypervisor's
+    // HOST_CR3 must point to page tables that persist in runtime memory.
+    // Build identity-mapped (virtual == physical) page tables using 2MB
+    // large pages, covering the first 512GB of physical address space.
+    //
+
+    //
+    // Allocate PML4 (1 page)
+    //
+    Pml4 = AllocateAlignedRuntimePages(1, EFI_PAGE_SIZE);
+    if (Pml4 == NULL)
+    {
+        return SHV_STATUS_NO_RESOURCES;
+    }
+    ZeroMem(Pml4, EFI_PAGE_SIZE);
+
+    //
+    // Allocate PDPT (1 page, 512 entries covering 512GB)
+    //
+    Pdpt = AllocateAlignedRuntimePages(1, EFI_PAGE_SIZE);
+    if (Pdpt == NULL)
+    {
+        FreeAlignedPages(Pml4, 1);
+        return SHV_STATUS_NO_RESOURCES;
+    }
+    ZeroMem(Pdpt, EFI_PAGE_SIZE);
+
+    //
+    // Allocate PD pages (512 pages, each with 512 entries of 2MB pages)
+    //
+    Pd = AllocateAlignedRuntimePages(PDPTE_ENTRY_COUNT, EFI_PAGE_SIZE);
+    if (Pd == NULL)
+    {
+        FreeAlignedPages(Pml4, 1);
+        FreeAlignedPages(Pdpt, 1);
+        return SHV_STATUS_NO_RESOURCES;
+    }
+    ZeroMem(Pd, PDPTE_ENTRY_COUNT * EFI_PAGE_SIZE);
+
+    //
+    // PML4[0] -> PDPT (Present | Read/Write)
+    //
+    Pml4[0] = (UINT64)Pdpt | 0x23;
+
+    //
+    // Fill PDPT entries, each pointing to a PD page
+    //
+    for (i = 0; i < PDPTE_ENTRY_COUNT; i++)
+    {
+        Pdpt[i] = ((UINT64)Pd + (i * EFI_PAGE_SIZE)) | 0x23;
+    }
+
+    //
+    // Fill PD entries with 2MB identity-mapped large pages
+    // Each entry: Present | Read/Write | Page Size (2MB)
+    //
+    for (i = 0; i < PDPTE_ENTRY_COUNT; i++)
+    {
+        UINT64 *PdPage = (UINT64*)((UINT64)Pd + (i * EFI_PAGE_SIZE));
+        for (j = 0; j < PDE_ENTRY_COUNT; j++)
+        {
+            UINT64 PhysAddr = ((UINT64)i * PDE_ENTRY_COUNT + j) * _2MB;
+            PdPage[j] = PhysAddr | 0x83;
+        }
+    }
+
+    //
+    // Override SystemDirectoryTableBase with our runtime page tables.
+    // In UEFI identity mapping, virtual address == physical address.
+    //
+    VpData->SystemDirectoryTableBase = (UINT64)Pml4;
+    return SHV_STATUS_SUCCESS;
+}
+
+INT32
+ShvOsBuildHostIdt (
+    _In_ PSHV_VP_DATA VpData
+    )
+{
+    VOID *HostIdt;
+
+    //
+    // The UEFI firmware's IDT resides in boot services memory and will be
+    // destroyed after ExitBootServices. Allocate a host IDT in runtime memory.
+    // The hypervisor runs with interrupts disabled, so entries are zeroed --
+    // but the memory itself must be valid to avoid triple faults if an NMI
+    // arrives during VMX root mode execution.
+    //
+    HostIdt = AllocateRuntimeZeroPool(EFI_PAGE_SIZE);
+    if (HostIdt == NULL)
+    {
+        return SHV_STATUS_NO_RESOURCES;
+    }
+
+    //
+    // Store the host IDT base for VMCS HOST_IDTR_BASE
+    //
+    VpData->HostIdtBase = (UINT64)HostIdt;
+    return SHV_STATUS_SUCCESS;
+}
+
+INT32
 ShvOsPrepareProcessor (
     _In_ PSHV_VP_DATA VpData
     )
@@ -162,6 +273,7 @@ ShvOsPrepareProcessor (
     PKGDTENTRY64 TssEntry, NewGdt;
     PKTSS64 Tss;
     KDESCRIPTOR Gdtr;
+    INT32 status;
 
     //
     // Clear AC in case it's not been reset yet
@@ -227,6 +339,28 @@ ShvOsPrepareProcessor (
     // Load the task register
     //
     _ltr(KGDT64_SYS_TSS);
+
+    //
+    // Build identity-mapped host page tables in runtime memory. The UEFI
+    // firmware's CR3 page tables will be destroyed after ExitBootServices,
+    // so HOST_CR3 must point to our own persistent page tables.
+    //
+    status = ShvOsBuildHostPageTables(VpData);
+    if (status != SHV_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    //
+    // Build a host IDT in runtime memory. The UEFI firmware's IDT will also
+    // be destroyed after ExitBootServices.
+    //
+    status = ShvOsBuildHostIdt(VpData);
+    if (status != SHV_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
     return SHV_STATUS_SUCCESS;
 }
 

--- a/uefi/simplevisor.inf
+++ b/uefi/simplevisor.inf
@@ -1,38 +1,39 @@
 [defines]
-  INF_VERSION = 0x00010005 
-  BASE_NAME = SimpleVisor
-  FILE_GUID = 22D5AE41-147E-4C44-AE72-ECD9BBB422D5
-  MODULE_TYPE = UEFI_APPLICATION
-  ENTRY_POINT = UefiMain
- 
+  INF_VERSION = 0x00010005
+  BASE_NAME = SimpleVisor
+  FILE_GUID = 22D5AE41-147E-4C44-AE72-ECD9BBB422D5
+  MODULE_TYPE = DXE_RUNTIME_DRIVER
+  ENTRY_POINT = UefiMain
+
 [Sources]
-  shv.c
-  shvutil.c
-  shvvmx.c
-  shvvmxhv.c
-  shvvp.c
-  uefi/shvos.c
- 
+  shv.c
+  shvutil.c
+  shvvmx.c
+  shvvmxhv.c
+  shvvp.c
+  uefi/shvos.c
+
 [Sources.X64]
-  shvvmxhvx64.asm
-  uefi/shvosx64.asm
- 
+  shvvmxhvx64.asm
+  uefi/shvosx64.asm
+
 [Packages]
-  MdePkg/MdePkg.dec
-  MdeModulePkg/MdeModulePkg.dec
-  IntelFrameworkPkg/IntelFrameworkPkg.dec  
-  IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec  
-  StdLib/StdLib.dec
- 
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  IntelFrameworkPkg/IntelFrameworkPkg.dec
+  IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+  StdLib/StdLib.dec
+
 [LibraryClasses]
-  UefiLib
-  UefiApplicationEntryPoint
-  UefiBootServicesTableLib
-  MemoryAllocationLib
-  DebugLib
- 
+  UefiLib
+  UefiDriverEntryPoint
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  MemoryAllocationLib
+  DebugLib
+
 [Protocols]
-  gEfiMpServiceProtocolGuid  
-  
+  gEfiMpServiceProtocolGuid
+
 [Depex]
-  TRUE 
+  TRUE

--- a/uefi/uefi.default.props
+++ b/uefi/uefi.default.props
@@ -11,7 +11,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/uefi/uefi.default.props
+++ b/uefi/uefi.default.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <EDK_PATH>C:\Users\aione\Documents\GitHub\VisualUefi\edk2</EDK_PATH>
+  <EDK_PATH>$(MSBuildProjectDirectory)\VisualUefi\edk2</EDK_PATH>
   </PropertyGroup>
   <PropertyGroup>
     <IncludePath>$(EDK_PATH)\MdePkg\Include;$(EDK_PATH)\MdePkg\Include\X64;$(EDK_PATH)\ShellPkg\Include;$(EDK_PATH)\CryptoPkg\Include</IncludePath>

--- a/uefi/uefi.props
+++ b/uefi/uefi.props
@@ -33,7 +33,7 @@
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
       <AdditionalDependencies>UefiHiiLib.lib;UefiHiiServicesLib.lib;UefiSortLib.lib;UefiShellLib.lib;GlueLib.lib;BaseLib.lib;BaseDebugPrintErrorLevelLib.lib;BasePrintLib.lib;UefiLib.lib;UefiBootServicesTableLib.lib;UefiRuntimeServicesTableLib.lib;UefiDevicePathLibDevicePathProtocol.lib;UefiDebugLibConOut.lib;UefiMemoryLib.lib;UefiMemoryAllocationLib.lib;BaseSynchronizationLib.lib;UefiFileHandleLib.lib;UefiDriverEntryPoint.lib</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <SubSystem>EFI Boot Service Driver</SubSystem>
+      <SubSystem>EFI Runtime Driver</SubSystem>
       <Driver>Driver</Driver>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding />


### PR DESCRIPTION
## Summary
This PR adds support for building and maintaining hypervisor page tables and interrupt descriptor tables (IDT) in UEFI runtime memory, ensuring they persist after `ExitBootServices()`. The changes convert SimpleVisor from a UEFI application to a DXE runtime driver and implement persistent host structures required for VMX operation.

## Key Changes

- **New host page table builder (`ShvOsBuildHostPageTables`)**: Allocates identity-mapped page tables in runtime memory covering the first 512GB of physical address space using 2MB large pages. This replaces reliance on firmware page tables that are freed after boot services exit.

- **New host IDT builder (`ShvOsBuildHostIdt`)**: Allocates a zeroed IDT in runtime memory to replace the firmware IDT that becomes invalid after `ExitBootServices()`. The IDT is kept valid to prevent triple faults if NMIs arrive during VMX root mode execution.

- **Updated `ShvOsPrepareProcessor`**: Integrated calls to build host page tables and IDT, storing the page table base in `VpData->SystemDirectoryTableBase` and IDT base in `VpData->HostIdtBase`.

- **VMCS host IDT configuration**: Modified `ShvVmxSetupVmcsForVp()` to use the custom persistent host IDT when available (UEFI path), falling back to the captured firmware IDT for non-UEFI environments.

- **Module type conversion**: Changed `simplevisor.inf` from `UEFI_APPLICATION` to `DXE_RUNTIME_DRIVER` and updated library dependencies to include `UefiRuntimeServicesTableLib` and `UefiDriverEntryPoint`.

- **Build system updates**: Added Visual Studio project filters, updated compiler settings for UEFI runtime driver configuration, and integrated VisualUefi as a git submodule for EDK2 dependencies.

## Implementation Details

- Page tables use 0x23 (Present | Read/Write) for directory entries and 0x83 (Present | Read/Write | Page Size) for 2MB page entries
- All runtime allocations use `AllocateAlignedRuntimePages()` and `AllocateRuntimeZeroPool()` to ensure memory persistence
- Proper error handling with resource cleanup on allocation failures
- Identity mapping maintained (virtual address == physical address) as required by UEFI environment

https://claude.ai/code/session_01Dmg6sBxavu9MpMJaFxY9a4